### PR TITLE
Fix compile issue with missing using statements

### DIFF
--- a/Services/ExcelCalculationService.cs
+++ b/Services/ExcelCalculationService.cs
@@ -1,5 +1,7 @@
 using OfficeOpenXml;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace BackendCalculationService.Services;
 


### PR DESCRIPTION
## Summary
- add missing System.IO and System.Linq usings for ExcelCalculationService

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684290bab2608333994b9603c3355f06