### PR TITLE
Fix ambiguous SaveAsync method

### DIFF
--- a/Models/CalculationRequest.cs
+++ b/Models/CalculationRequest.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace BackendCalculationService.Models;
 
 public class CalculationRequest

--- a/Notifications/CalculationHub.cs
+++ b/Notifications/CalculationHub.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.SignalR;
+using System.Threading.Tasks;
 
 namespace BackendCalculationService.Notifications;
 

--- a/Services/ExcelCalculationService.cs
+++ b/Services/ExcelCalculationService.cs
@@ -2,6 +2,7 @@ using OfficeOpenXml;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace BackendCalculationService.Services;
 

--- a/Services/WorkbookStorageService.cs
+++ b/Services/WorkbookStorageService.cs
@@ -26,9 +26,4 @@ public class WorkbookStorageService
     {
         return new FileInfo(Path.Combine(_storagePath, filename));
     }
-
-    internal async Task SaveAsync(IFormFile file)
-    {
-        throw new NotImplementedException();
-    }
 }


### PR DESCRIPTION
## Summary
- remove duplicate `SaveAsync` definition
- add missing `System.Threading.Tasks` and `System.Collections.Generic` usings

## Testing
- `dotnet build` *(fails: `WebApplication` does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6846bbd57c008333908b38f1911dd1ef